### PR TITLE
Symlink $BUILDHOME/.gfclient to $GLASSFISH_HOME/glassfish/domains

### DIFF
--- a/bin/mkenv
+++ b/bin/mkenv
@@ -17,6 +17,7 @@ maindir = Path(__file__).resolve().parent.parent
 env_file = maindir / '.env'
 home_src_dir = maindir / 'build' / 'home'
 glassfish_home = Path('/opt/payara6')
+domains_dir = glassfish_home / 'glassfish' / 'domains'
 uid = str(os.getuid())
 gid = str(os.getgid())
 
@@ -61,6 +62,7 @@ def mkhome(user):
         if gitconfig.exists():
             copyfile(str(gitconfig), str(home / '.gitconfig'))
         (home / 'bin').symlink_to(glassfish_home / 'bin')
+        (home / '.gfclient').symlink_to(domains_dir / '.gfclient')
         try:
             lt = Path('/etc/localtime')
             zi = Path('/usr/share/zoneinfo/')

--- a/build/image/start-glassfish.sh
+++ b/build/image/start-glassfish.sh
@@ -8,6 +8,7 @@ export DOMAINDIR
 
 
 glassfish_init() {
+    mkdir -p $GLASSFISH_HOME/glassfish/domains/.gfclient
     adminpw="$(pwgen -s 32 1)"
     pwfile=$(mktemp)
     echo "AS_ADMIN_PASSWORD=${adminpw}" > $pwfile


### PR DESCRIPTION
Make sure that `.gfclient` storing the Payara domain credentials is created inside the `mvn_gfdomain` volume, so it will be persisted there together with the domain.

Close #2.